### PR TITLE
複数のバグを解決 ＆ rubocopによるリファクタリングを実施

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -26,7 +26,7 @@ DIRECTIONS = [
 def output(board)
   puts "  #{ROW.join(' ')}"
   board.each.with_index do |row, i|
-    print COL[i].to_s
+    print COL[i]
     row.each do |cell|
       case cell
       when WHITE_STONE then print ' ○'

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -53,7 +53,7 @@ def put_stone!(board, cellstr, stone_color, execute = true) # rubocop:disable St
 
   # コピーした盤面にて石の配置を試みて、成功すれば反映する
   copied_board = Marshal.load(Marshal.dump(board))
-  copied_board[pos.row][pos.col] = stone_color
+  copied_board[pos.col][pos.row] = stone_color
 
   turn_succeed = false
   DIRECTIONS.each do |direction|

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -69,7 +69,7 @@ end
 # target_posはひっくり返す対象セル
 def turn!(board, target_pos, attack_stone_color, direction)
   return false if target_pos.out_of_board?
-  return false if target_pos.stone_color(board) == attack_stone_color
+  return false if [attack_stone_color, BLANK_CELL].include?(target_pos.stone_color(board))
 
   next_pos = target_pos.next_position(direction)
   if (next_pos.stone_color(board) == attack_stone_color) || turn!(board, next_pos, attack_stone_color, direction)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -93,6 +93,7 @@ def placeable?(board, attack_stone_color)
       return true if put_stone!(board, position.to_cellstr, attack_stone_color, false)
     end
   end
+  false
 end
 
 def count_stone(board, stone_color)


### PR DESCRIPTION
以下の通り、プログラムを修正しました。
ご確認をお願い致します🙇

# 対象のバグ
1. 指定した座標に石が配置されない（指定した行と列が入れ替わった座標に配置される）
2. 石を配置した際、空白セルも反転対象のマスと認識されていて石が置かれてしまう
3. 全てのマスに石が置かれた場合、ゲームが終了されない

# 修正内容
## バグ修正
1. `put_stone!`メソッドにおいて、コピーした盤面に配置した石の`col`と`row`が逆になっていた部分を修正
2. `turn!`メソッドにおいて、空白セルの場合も`true`を返していた（反転対象のセルとしていた）部分を、`false`を返すように修正
3. `placeable?`メソッドにおいて、石の配置が不可だった場合に戻り値が宣言されていなかった（`nil`が戻り値となっていた）部分を、明示的に`false`を返すように修正
## リファクタリング（rubocop）
4. `output`メソッドで、不要な文字列変換処理（`to_s`メソッド）を削除